### PR TITLE
Update env-scm-1.rockspec

### DIFF
--- a/env-scm-1.rockspec
+++ b/env-scm-1.rockspec
@@ -16,7 +16,6 @@ Adds pretty printing and additional path handling to luajit
 
 dependencies = {
    "torch >= 7.0",
-   "gnuplot",
    "dok"
 }
 


### PR DESCRIPTION
If we don't import gnuplot, why require it in the rockspec?
